### PR TITLE
SDS-3287 pass through required kibana headers after upgrade to ES 7.10

### DIFF
--- a/aws-es-proxy.go
+++ b/aws-es-proxy.go
@@ -242,7 +242,7 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // Recent versions of ES/Kibana require
-// "kbn-version" and "content-type: application/json"
+// "kbn-version", "kbn-xsrf", "authorization" and "content-type: application/json"
 // headers to exist in the request.
 // If missing requests fails.
 func addHeaders(src, dest http.Header) {

--- a/aws-es-proxy.go
+++ b/aws-es-proxy.go
@@ -253,6 +253,14 @@ func addHeaders(src, dest http.Header) {
 	if val, ok := src["Content-Type"]; ok {
 		dest.Add("Content-Type", val[0])
 	}
+
+	if val, ok := src["Kbn-Xsrf"]; ok {
+		dest.Add("Kbn-Xsrf", val[0])
+	}
+
+	if val, ok := src["Authorization"]; ok {
+		dest.Add("Authorization", val[0])
+	}
 }
 
 // Signer.Sign requires a "seekable" body to sum body's sha256


### PR DESCRIPTION
pass through the new `Kbn-Xsrf` header required for Kibana to work after upgrading to ES 7.10.

I did look at incorporating all the recent changes from the upstream project https://github.com/abutaha/aws-es-proxy (among others they have made the change below), but I don't have enough knowledge to do it without much risk/time investment.  

This will need to be merged, released and the new version included in XGW (separate PR there incoming)

