### PR TITLE
SDPT-5369 | Adding headers for opensearch

### DIFF
--- a/aws-es-proxy.go
+++ b/aws-es-proxy.go
@@ -261,6 +261,17 @@ func addHeaders(src, dest http.Header) {
 	if val, ok := src["Authorization"]; ok {
 		dest.Add("Authorization", val[0])
 	}
+
+// Since AWS rebranded ES/Kibana to OpenSearch, they rebranded their headers as well
+// So we need these two osd headers instead of the above kbn headers to work on OpenSearch
+// Leaving the old ones for backwards compatibility
+	if val, ok := src["osd-version"]; ok {
+		dest.Add("osd-xsrf", val[0])
+	}
+
+	if val, ok := src["osd-xsrf"]; ok {
+		dest.Add("osd-xsrf", val[0])
+	}
 }
 
 // Signer.Sign requires a "seekable" body to sum body's sha256


### PR DESCRIPTION
Needed for XGW to proxy to AWS Opensearch since AWS' move from Elasticsearch to Opensearch.

Will also need some changes to the XGW nginx redirection due to URL changes, I'll raise another PR for that shortly.